### PR TITLE
LuaFunction 支持枚举类型的参数， 以及重写lua内部的loadfile和dofile函数

### DIFF
--- a/Assets/Slua/Script/LuaObject.cs
+++ b/Assets/Slua/Script/LuaObject.cs
@@ -1199,8 +1199,12 @@ return index
 			PushVarDelegate push;
 			if (typePushMap.TryGetValue(t, out push))
 				push(l, o);
+			else if (t.IsEnum)
+			{
+				pushEnum(l, Convert.ToInt32(o));
+			}
 			else
-				pushObject(l, o);
+				pushObject(l,o);           
 		}
 
 

--- a/Assets/Slua/Script/LuaState.cs
+++ b/Assets/Slua/Script/LuaState.cs
@@ -440,6 +440,12 @@ namespace SLua
 			LuaDLL.lua_pushstdcallcfunction(L, import);
 			LuaDLL.lua_setglobal(L, "import");
 
+			LuaDLL.lua_pushstdcallcfunction(L, dofile);
+			LuaDLL.lua_setglobal(L, "dofile");
+
+			LuaDLL.lua_pushstdcallcfunction(L, loadfile);
+			LuaDLL.lua_setglobal(L, "loadfile");
+
 			LuaDLL.lua_pushstdcallcfunction(L, loader);
 			int loaderFunc = LuaDLL.lua_gettop(L);
 
@@ -586,6 +592,23 @@ namespace SLua
 			return 0;
 		}
 
+		[MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]
+		internal static int loadfile(IntPtr L)
+		{
+			return loader(L);
+		}
+
+		[MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]
+		internal static int dofile(IntPtr L)
+		{
+			int n = LuaDLL.lua_gettop(L);
+
+			if (loader(L) != 0) return LuaDLL.lua_gettop(L) - n;
+
+			LuaDLL.lua_call(L, 0, LuaDLL.LUA_MULTRET);
+			return LuaDLL.lua_gettop(L) - n;
+		}
+		
 		[MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]
 		internal static int loader(IntPtr L)
 		{


### PR DESCRIPTION
我增加了两处功能，请星雨大神过目
针对我遇到的以下两个问题
1. 枚举类型通过LuaFunction call传递到lua中会被当成userdata。
2.在lua内部调用loadfile和dofile函数时，跟require一样采用自定义的loader