### PR TITLE
Update LuaObject.cs

### DIFF
--- a/Assets/Slua/Script/LuaObject.cs
+++ b/Assets/Slua/Script/LuaObject.cs
@@ -776,7 +776,13 @@ return index
 			v = (short)LuaDLL.luaL_checkinteger(l, p);
 			return true;
 		}
-
+		
+		static public bool checkType(IntPtr l, int p, out UInt16 v)
+		{
+			v = (UInt16)LuaDLL.luaL_checkinteger(l, p);
+			return true;
+		}
+		
 		static public bool checkType(IntPtr l, int p, out byte v)
 		{
 			v = (byte)LuaDLL.luaL_checkinteger(l, p);


### PR DESCRIPTION
修复 ushort 类型的set导出问题

类似下面函数的导出
class ushortOutputTest
{
    public ushort map_id_
}