### PR TITLE
Add `As` method

### DIFF
--- a/Assets/Slua/Script/Helper.cs
+++ b/Assets/Slua/Script/Helper.cs
@@ -197,14 +197,28 @@ return Class
 			}
 			return 1;
 		}
-
+		
+		[MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]
+		static public int As(IntPtr l)
+		{
+			if (!isTypeTable (l, 2)) {
+				LuaDLL.luaL_error(l,"No matched type of param 2");
+				return 0;
+			}
+			string meta = LuaDLL.lua_tostring (l, -1);
+			LuaDLL.luaL_getmetatable (l, meta);
+			LuaDLL.lua_setmetatable (l, 1);
+			LuaDLL.lua_pushvalue (l, 1);
+			return 1;
+		}
+		
 		static public void reg(IntPtr l)
 		{
 			reg(l, CreateClass, "Slua");
 			reg(l, GetClass, "Slua");
 			reg(l, iter, "Slua");
 			reg(l, ToString, "Slua");
-
+			reg(l, As, "Slua");
 
 			newTypeTable(l, "Slua");
 			if (LuaDLL.luaL_dostring(l, classfunc) != 0)

--- a/Assets/Slua/Script/LuaObject.cs
+++ b/Assets/Slua/Script/LuaObject.cs
@@ -682,7 +682,7 @@ return index
 			return false;
 		}
 
-		static bool isTypeTable(IntPtr l, int p)
+		public static bool isTypeTable(IntPtr l, int p)
 		{
 			if (LuaDLL.lua_type(l, p) != LuaTypes.LUA_TTABLE)
 				return false;


### PR DESCRIPTION
So we can use a object as it's parent type. For example:
`obj` is a instance of class `FishEye`, and we did not need to export this class or use the object by reflection. We only want to use the `obj` as `UnityEngine.Behaviour` so we can call `obj.enabled = true`.

```
local obj = Slua.As(camera_boom:GetComponent("FishEye"), UnityEngine.Behaviour)
obj.enabled = true
```