### PR TITLE
- fix：修复导出Camera的静态委托属性时候，编译dll导入第一次会报多个元素存在的error问题。

### DIFF
--- a/Assets/Slua/Editor/LuaCodeGen.cs
+++ b/Assets/Slua/Editor/LuaCodeGen.cs
@@ -884,6 +884,11 @@ namespace SLua
 			{
 				if (DontExport(fi) || IsObsolete(fi))
 					continue;
+                if (fi.IsStatic && fi.FieldType.BaseType == typeof(MulticastDelegate))
+                {
+                    Debug.LogWarning("static delegate field not support :" + fi.FieldType.ToString() + "." + fi.Name);
+                    continue;
+                }
 
 				PropPair pp = new PropPair();
 				pp.isInstance = !fi.IsStatic;


### PR DESCRIPTION
1:make slua bind Camera
2:build this LuaObject files to dll.
3:input this dll in new unity project

will show error like this every time: 
![slua_dll_erro](https://cloud.githubusercontent.com/assets/1845859/7799527/d4ebac42-0339-11e5-9632-15f76f7afd68.jpg)
