### PR TITLE
1.Fix generate error code when exporting the generic value type, e.g.…

### DIFF
--- a/Assets/Slua/Editor/LuaCodeGen.cs
+++ b/Assets/Slua/Editor/LuaCodeGen.cs
@@ -723,7 +723,7 @@ namespace SLua
 		{
 			// Write export function
 			Write(file, "static public void reg(IntPtr l) {");
-			Write(file, "getEnumTable(l,\"{0}\");", FullName(t));
+			Write(file, "getEnumTable(l,\"{0}\");", string.IsNullOrEmpty(givenNamespace) ? FullName(t) : givenNamespace);
 			
 			FieldInfo[] fields = t.GetFields();
 			foreach (FieldInfo f in fields)
@@ -837,7 +837,7 @@ namespace SLua
 				Write(file, "LuaUnityEvent_{1}.reg(l);", FullName(t), _Name((GenericName(t.BaseType))));
 			}
 			
-			Write(file, "getTypeTable(l,\"{0}\");", givenNamespace != null ? givenNamespace : FullName(t));
+			Write(file, "getTypeTable(l,\"{0}\");", string.IsNullOrEmpty(givenNamespace) ? FullName(t) : givenNamespace);
 			foreach (string f in funcname)
 			{
 				Write(file, "addMember(l,{0});", f);
@@ -1488,7 +1488,7 @@ namespace SLua
 		{
 			if (t.IsValueType)
 			{
-				Write(file, "{0} self;", FullName(t));
+				Write(file, "{0} self;", TypeDecl(t));
 				Write(file, "checkType(l,1,out self);");
 			}
 			else


### PR DESCRIPTION
1.
I try to iterate Dictionary in lua, and try to export KeyValuePair to lua in order to access the key and value, but the generated code like this:
```c#
    [MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]
    static public int get_Key(IntPtr l) {
        try {
            KeyValuePair<<System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089>,<MyClassType, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null>> self;
            checkType(l,1,out self);
            pushValue(l,self.Key);
            return 1;
        }
        catch(Exception e) {
            LuaDLL.luaL_error(l, e.ToString());
            return 0;
        }
    }
```
2. 
Let user to change enum name:
A.B.Enum
->
add(typeof(A.B.Enum), "AB.Enum");