### PR TITLE
实现接口ICustomExportPost

### DIFF
--- a/Assets/Slua/Editor/ICustomExportPost.cs
+++ b/Assets/Slua/Editor/ICustomExportPost.cs
@@ -1,0 +1,8 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace SLua{
+	public interface ICustomExportPost {
+
+	}
+}

--- a/Assets/Slua/Editor/ICustomExportPost.cs.meta
+++ b/Assets/Slua/Editor/ICustomExportPost.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d9383b1d0c17c4785b6f689a7253bb61
+timeCreated: 1446453567
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Slua/Editor/LuaCodeGen.cs
+++ b/Assets/Slua/Editor/LuaCodeGen.cs
@@ -273,14 +273,34 @@ namespace SLua
             }
 
             CustomExport.OnAddCustomClass(fun);
+
+
 			
+			//detect interface ICustomExportPost,and call OnAddCustomClass
+			InvokeEditorMethond<ICustomExportPost>("OnAddCustomClass",new object[]{fun});
+
+
 			GenerateBind(exports, "BindCustom", 3, path);
             if(autoRefresh)
 			    AssetDatabase.Refresh();
 			
 			Debug.Log("Generate custom interface finished");
 		}
-		
+
+		static private void InvokeEditorMethond<T>(string methodName,object[] parameters){
+			System.Reflection.Assembly editorAssembly = System.Reflection.Assembly.Load("Assembly-CSharp-Editor");
+			Type[] editorTypes = editorAssembly.GetExportedTypes();
+			foreach (Type t in editorTypes)
+			{
+				if(typeof(T).IsAssignableFrom(t)){
+					System.Reflection.MethodInfo method =  t.GetMethod(methodName,System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
+					if(method != null){
+						method.Invoke(null,parameters);
+					}
+				}
+			}
+		}
+
 		[MenuItem("SLua/3rdDll/Make")]
 		static public void Generate3rdDll()
 		{
@@ -291,6 +311,10 @@ namespace SLua
 			List<Type> cust = new List<Type>();
 			List<string> assemblyList = new List<string>();
 			CustomExport.OnAddCustomAssembly(ref assemblyList);
+
+			//detect interface ICustomExportPost,and call OnAddCustomAssembly
+			InvokeEditorMethond<ICustomExportPost>("OnAddCustomAssembly",new object[]{assemblyList});
+
 			foreach (string assemblyItem in assemblyList)
 			{
 				Assembly assembly = Assembly.Load(assemblyItem);

--- a/Assets/Slua/Editor/LuaCodeGen.cs
+++ b/Assets/Slua/Editor/LuaCodeGen.cs
@@ -277,7 +277,7 @@ namespace SLua
 
 			
 			//detect interface ICustomExportPost,and call OnAddCustomClass
-			InvokeEditorMethond<ICustomExportPost>("OnAddCustomClass",new object[]{fun});
+			InvokeEditorMethod<ICustomExportPost>("OnAddCustomClass",new object[]{fun});
 
 
 			GenerateBind(exports, "BindCustom", 3, path);
@@ -287,7 +287,7 @@ namespace SLua
 			Debug.Log("Generate custom interface finished");
 		}
 
-		static private void InvokeEditorMethond<T>(string methodName,object[] parameters){
+		static private void InvokeEditorMethod<T>(string methodName,object[] parameters){
 			System.Reflection.Assembly editorAssembly = System.Reflection.Assembly.Load("Assembly-CSharp-Editor");
 			Type[] editorTypes = editorAssembly.GetExportedTypes();
 			foreach (Type t in editorTypes)
@@ -313,7 +313,7 @@ namespace SLua
 			CustomExport.OnAddCustomAssembly(ref assemblyList);
 
 			//detect interface ICustomExportPost,and call OnAddCustomAssembly
-			InvokeEditorMethond<ICustomExportPost>("OnAddCustomAssembly",new object[]{assemblyList});
+			InvokeEditorMethod<ICustomExportPost>("OnAddCustomAssembly",new object[]{assemblyList});
 
 			foreach (string assemblyItem in assemblyList)
 			{


### PR DESCRIPTION
实现接口ICustomExportPost,可以在Make custom的时候 自动调用
OnAddCustomClass，以及make 3rd dll的时候自动调用 OnAddCustomAssembly,
这样就不必改动Custom.cs,避免更新框架的时候被覆盖。
example:

	public class TestExport : SLua.ICustomExportPost {

		public static void OnAddCustomClass(LuaCodeGen.ExportGenericDelegate add)
		{
			Debug.Log("make custom class ");
		}

		public static void OnAddCustomAssembly(ref List<string> list)
		{
			Debug.Log("make assembly");
		}
	}