### PR TITLE
Support for extension method export

### DIFF
--- a/Assets/Slua/Editor/LuaCodeGen.cs
+++ b/Assets/Slua/Editor/LuaCodeGen.cs
@@ -1566,12 +1566,11 @@ namespace SLua
 			List<MethodBase> methods = new List<MethodBase>();
 
 			if(this.includeExtension && ((bf&BindingFlags.Instance) == BindingFlags.Instance)){
-				if(!extensionMethods.ContainsKey(t)){
-					return new MethodBase[]{};
-				}
-				foreach(MethodInfo m in extensionMethods[t]){
-					if(m.Name == name){
-						methods.Add(m);
+				if(extensionMethods.ContainsKey(t)){
+					foreach(MethodInfo m in extensionMethods[t]){
+						if(m.Name == name){
+							methods.Add(m);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
支持c#扩展方法的导出.
例如:

	public Class A{
	}

	public static Class AExt{		
		public static void test(this A a,int arg){
		}
	}
在lua里可以直接调用：
    `local a = A()`
    `  a:test(1)`