### PR TITLE
fix code generate path bug.

### DIFF
--- a/Assets/Slua/Editor/LuaCodeGen.cs
+++ b/Assets/Slua/Editor/LuaCodeGen.cs
@@ -112,12 +112,16 @@ namespace SLua
 			
 			static Startup()
 			{
+			}
+
+			[UnityEditor.Callbacks.DidReloadScripts]
+			public static void OnDidReloadScripts(){
 				bool ok = System.IO.Directory.Exists(SLuaSetting.Instance.UnityEngineGeneratePath);
 				if (!ok && EditorUtility.DisplayDialog("Slua", "Not found lua interface for Unity, generate it now?", "Generate", "No"))
 				{
 					GenerateAll();
 				}
-			}
+			} 
 		}
 	
 		[MenuItem("SLua/All/Make")]
@@ -502,7 +506,7 @@ namespace SLua
 		public void GenerateBind(List<Type> list, string name, int order)
 		{
 			HashSet<Type> exported = new HashSet<Type>();
-			string f = path + name + ".cs";
+			string f = System.IO.Path.Combine(path , name + ".cs");
 			StreamWriter file = new StreamWriter(f, false, Encoding.UTF8);
 			file.NewLine = NewLine;
 			Write(file, "using System;");


### PR DESCRIPTION
There are two bugs fixed here.

1. The static constructor of LuaCodeGen.StartUp is called before
unity’s serialization works.So the value of
`SLuaSetting.Instance.UnityEngineGeneratePath` is always default.
We can move the check code to `DidReloadScripts callback` to fix it.

2.Use `Path.Combine` instead of `path+name`. If user set path =
‘slua/Unity’ without ending of ‘/’, the generated file path will become
`slua/Unity{Name}`.
