### PR TITLE
支持Editor下使用LuaSvr；自动去除UTF-8 BOM

### DIFF
--- a/Assets/Plugins/Slua_Managed/LuaState.cs
+++ b/Assets/Plugins/Slua_Managed/LuaState.cs
@@ -912,22 +912,26 @@ end
 			return null;
 		}
 
+	    /// <summary>
+	    /// Ensure remove BOM from bytes
+	    /// </summary>
+	    /// <param name="bytes"></param>
+	    /// <returns></returns>
+	    public static byte[] CleanUTF8Bom(byte[] bytes)
+	    {
+            if (bytes.Length > 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+            {
+                var oldBytes = bytes;
+                bytes = new byte[bytes.Length - 3];
+                Array.Copy(oldBytes, 3, bytes, 0, bytes.Length);
+            }
+            return bytes;
+	    }
+
 		public bool doBuffer(byte[] bytes, string fn, out object ret)
         {        
             // ensure no utf-8 bom, LuaJIT can read BOM, but Lua cannot!
-            if (bytes.Length > 3)
-            {
-                if (bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
-                {
-                    var oldBytes = bytes;
-                    bytes = new byte[bytes.Length - 3];
-                    for (var i = 0; i < bytes.Length; i++)
-                    {
-                        bytes[i] = oldBytes[i + 3];
-                    }
-                }
-            }
-
+		    bytes = CleanUTF8Bom(bytes);
             ret = null;
 			int errfunc = LuaObject.pushTry(L);
 			if (LuaDLL.luaL_loadbuffer(L, bytes, bytes.Length, fn) == 0)

--- a/Assets/Plugins/Slua_Managed/LuaState.cs
+++ b/Assets/Plugins/Slua_Managed/LuaState.cs
@@ -913,8 +913,22 @@ end
 		}
 
 		public bool doBuffer(byte[] bytes, string fn, out object ret)
-		{
-			ret = null;
+        {        
+            // ensure no utf-8 bom, LuaJIT can read BOM, but Lua cannot!
+            if (bytes.Length > 3)
+            {
+                if (bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+                {
+                    var oldBytes = bytes;
+                    bytes = new byte[bytes.Length - 3];
+                    for (var i = 0; i < bytes.Length; i++)
+                    {
+                        bytes[i] = oldBytes[i + 3];
+                    }
+                }
+            }
+
+            ret = null;
 			int errfunc = LuaObject.pushTry(L);
 			if (LuaDLL.luaL_loadbuffer(L, bytes, bytes.Length, fn) == 0)
 			{

--- a/Assets/Plugins/Slua_Managed/LuaSvr.cs
+++ b/Assets/Plugins/Slua_Managed/LuaSvr.cs
@@ -200,6 +200,7 @@ namespace SLua
 		public void init(Action<int> tick,Action complete,LuaSvrFlag flag=LuaSvrFlag.LSF_BASIC)
         {
 			LuaState luaState = new LuaState();
+            this.luaState = luaState;
 
 			IntPtr L = luaState.L;
 			LuaObject.init(L);
@@ -221,7 +222,6 @@ namespace SLua
 
 			lgo.StartCoroutine(waitForBind(tick, () =>
 			{
-				this.luaState = luaState;
 				doinit(L,flag);
 				complete();
 				checkTop(L);

--- a/Assets/Plugins/Slua_Managed/LuaSvr.cs
+++ b/Assets/Plugins/Slua_Managed/LuaSvr.cs
@@ -225,7 +225,6 @@ namespace SLua
 
 #if SLUA_STANDALONE
             doBind(L);
-		    this.luaState = luaState;
             doinit(L, flag);
 		    complete();
             checkTop(L);

--- a/Assets/Plugins/Slua_Managed/LuaVarObject.cs
+++ b/Assets/Plugins/Slua_Managed/LuaVarObject.cs
@@ -85,6 +85,8 @@ namespace SLua
                                 return str;
                         }
                         break;
+                    case "Decimal":
+                        return (decimal)LuaDLL.lua_tointeger(l, p);
                     case "Int64":
                         return (long)LuaDLL.lua_tointeger(l, p);
                     case "UInt64":

--- a/Assets/Plugins/Slua_Managed/LuaVarObject.cs
+++ b/Assets/Plugins/Slua_Managed/LuaVarObject.cs
@@ -85,6 +85,10 @@ namespace SLua
                                 return str;
                         }
                         break;
+                    case "Int64":
+                        return (long)LuaDLL.lua_tointeger(l, p);
+                    case "UInt64":
+                        return (ulong)LuaDLL.lua_tointeger(l, p);
                     case "Int32":
                         return (int)LuaDLL.lua_tointeger(l, p);
                     case "UInt32":

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Mail to : sineysan#163.com (both of Chinese/English)
 
 ##Release Download
 
-[here.](https://github.com/pangweiwei/slua/releases/latest)
+[slua-unity](https://github.com/pangweiwei/slua/releases/latest)
+[slua-standalone](https://www.nuget.org/packages/slua-standalone)
 
 ##Integrate with 3rd Lua Library
 
@@ -47,33 +48,20 @@ Click menu, SLua->All->Make  generate all wrap file for your version of unity.
 
 ##Main feature
 
-static code generating, no reflection, no extra gc alloc, very fast
-
-remote debugger
-
-full support iOS/iOS64, support il2cpp
-
-above 90% UnityEngine interface exported ( remove flash, platform dependented interface )
-
-100% UnityEngine.UI interface ( require Unity4.6+ )
-
-support standalone in mono without Unity3D
-
-support UnityEvent/UnityAction for event callback via lua function
-
-support delegate via lua function (include iOS)
-
-support yield call
-
-support custom class exported
-
-support extension method
-
-export enum as integer
-
-return array as lua table
-
-using raw luajit, can be replaced with lua5.3/lua5.1
+- static code generating, no reflection, no extra gc alloc, very fast
+- remote debugger
+- full support iOS/iOS64, support il2cpp
+- above 90% UnityEngine interface exported ( remove flash, platform dependented interface )
+- 100% UnityEngine.UI interface ( require Unity4.6+ )
+- support standalone mode in .net framework/mono without Unity3D
+- support UnityEvent/UnityAction for event callback via lua function
+- support delegate via lua function (include iOS)
+- support yield call
+- support custom class exported
+- support extension method
+- export enum as integer
+- return array as lua table
+- using raw luajit, can be replaced with lua5.3/lua5.1
 
 ##Usage
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Mail to : sineysan#163.com (both of Chinese/English)
 
 ##Release Download
 
-[slua-unity](https://github.com/pangweiwei/slua/releases/latest)
-[slua-standalone](https://www.nuget.org/packages/slua-standalone)
+- [slua-unity](https://github.com/pangweiwei/slua/releases/latest)
+- [slua-standalone](https://www.nuget.org/packages/slua-standalone)
 
 ##Integrate with 3rd Lua Library
 

--- a/standalone/slua-standalone-tests/TestSLua.cs
+++ b/standalone/slua-standalone-tests/TestSLua.cs
@@ -98,5 +98,22 @@ return TestSLua
             var ret = _luaSvr.luaState.doString(code);
             Assert.AreEqual(321, ret);
         }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static decimal DoMethodDecimal(decimal a1, decimal a2)
+        {
+            Assert.AreEqual(123, a1);
+            return a2;
+        }
+
+        [Test]
+        public void DoMethodDecimal()
+        {
+            var code = @"
+    local TestSLua = Slua.GetClass('SLua.Test.TestSLua')
+    return TestSLua.DoMethodDecimal(123, 321)
+";
+            var ret = _luaSvr.luaState.doString(code);
+            Assert.AreEqual(321, ret);
+        }
     }
 }

--- a/standalone/slua-standalone-tests/TestSLua.cs
+++ b/standalone/slua-standalone-tests/TestSLua.cs
@@ -80,5 +80,23 @@ return TestSLua
             var ret = _luaSvr.luaState.doString(code);
             Assert.AreEqual(123, ret);
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static ulong DoMethodLong(long a1, ulong a2)
+        {
+            Assert.AreEqual(123, a1);
+            return a2;
+        }
+
+        [Test]
+        public void DoMethodLong()
+        {
+            var code = @"
+    local TestSLua = Slua.GetClass('SLua.Test.TestSLua')
+    return TestSLua.DoMethodLong(123, 321)
+";
+            var ret = _luaSvr.luaState.doString(code);
+            Assert.AreEqual(321, ret);
+        }
     }
 }

--- a/standalone/slua-standalone-tests/TestSLua.cs
+++ b/standalone/slua-standalone-tests/TestSLua.cs
@@ -115,5 +115,31 @@ return TestSLua
             var ret = _luaSvr.luaState.doString(code);
             Assert.AreEqual(321, ret);
         }
+
+
+        [Test]
+        public void UTF8Bom()
+        {
+            var bytes = Encoding.UTF8.GetBytes("return 1");
+
+            var bomBytes = new byte[bytes.Length + 3];
+            Array.Copy(bytes, 0, bomBytes, 3, bytes.Length);
+
+            bomBytes[0] = 0xEF;
+            bomBytes[1] = 0xBB;
+            bomBytes[2] = 0xBF;
+
+
+
+            object ret;
+            Assert.IsTrue(_luaSvr.luaState.doBuffer(bomBytes, "TestUtf8Bom", out ret));
+            Assert.AreEqual(1, ret);
+
+            // Test BOM filter
+            var noBomBytes = SLua.LuaState.CleanUTF8Bom(bomBytes);
+            Assert.AreNotEqual(noBomBytes[0], 0xEF);
+            Assert.AreNotEqual(noBomBytes[0], 0xBB);
+            Assert.AreNotEqual(noBomBytes[0], 0xBF);
+        }
     }
 }


### PR DESCRIPTION
- 支持Editor下使用LuaSvr，为了直接使用Lua写编程工具，并在[KSFramework](https://github.com/mr-kelly/KSFramework)中使用Lua单元测试；

- doBuffer函数添加自动去除UTF-8 BOM，IOS Lua（非LuaJIT）不支持UTF-8 BOM；

- this.luaState = luaState;提早执行；避免一些较早使用luaState的场合提示NullException