### PR TITLE
add code generator for op_UnaryPlus

### DIFF
--- a/Assets/Slua/Editor/LuaCodeGen.cs
+++ b/Assets/Slua/Editor/LuaCodeGen.cs
@@ -1977,6 +1977,8 @@ namespace SLua
 					Write(file, "{0}a1/a2;", ret);
 				else if (m.Name == "op_UnaryNegation")
 					Write(file, "{0}-a1;", ret);
+				else if (m.Name == "op_UnaryPlus")
+					Write(file, "{0}+a1;", ret);
 				else if (m.Name == "op_Equality")
 					Write(file, "{0}(a1==a2);", ret);
 				else if (m.Name == "op_Inequality")


### PR DESCRIPTION
Currently, LuaCodeGen doesn't support for op_UnaryPlus method.
When the user adds such type in CustomExport,
generated code makes build fail.
example : https://msdn.microsoft.com/en-us/library/system.timespan.op_unaryplus(v=vs.80).aspx