### PR TITLE
avoid IsAlive

### DIFF
--- a/Assets/Plugins/Slua_Managed/BytesHelper.dll.meta
+++ b/Assets/Plugins/Slua_Managed/BytesHelper.dll.meta
@@ -1,0 +1,24 @@
+fileFormatVersion: 2
+guid: c9878be7658f80640b096c775aadd2b6
+timeCreated: 1506315016
+licenseType: Free
+PluginImporter:
+  serializedVersion: 1
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  platformData:
+    Any:
+      enabled: 1
+      settings: {}
+    Editor:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+    WindowsStoreApps:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Slua_Managed/WeakDictionary.cs
+++ b/Assets/Plugins/Slua_Managed/WeakDictionary.cs
@@ -36,8 +36,10 @@ namespace SLua
 			get
 			{
 				WeakReference w = _dict[key];
-				if (w.IsAlive)
-					return (V)w.Target;
+                // IsAlive is not reliable in IL2CPP
+                V value = (V)w.Target;
+				if (value != null)
+					return value;
 				return default(V);
 			}
 
@@ -72,7 +74,7 @@ namespace SLua
 		{
 			if (_dict.ContainsKey(key))
 			{
-				if (_dict[key].IsAlive)
+				if (_dict[key].Target != null)
 					throw new ArgumentException("key exists");
 
 				_dict[key].Target = value;


### PR DESCRIPTION
`WeakReference.IsAlive` is not reliable for IL2CPP. We encoutered bugs with this before (`IsAvlie=true` but `Target=null`)
http://blog.csdn.net/zhangdi2017/article/details/59791339