### PR TITLE
Multiple nested classes are not generated.

### DIFF
--- a/Assets/Slua/Editor/LuaCodeGen.cs
+++ b/Assets/Slua/Editor/LuaCodeGen.cs
@@ -892,8 +892,9 @@ namespace SLua
 			if (!t.IsGenericTypeDefinition && (!IsObsolete(t) && t != typeof(YieldInstruction) && t != typeof(Coroutine))
 			    || (t.BaseType != null && t.BaseType == typeof(System.MulticastDelegate)))
 			{
-
-				if (t.IsNested && t.DeclaringType.IsPublic == false)
+				if (t.IsNested
+					&& ((!t.DeclaringType.IsNested && t.DeclaringType.IsPublic == false)
+					|| (t.DeclaringType.IsNested && t.DeclaringType.IsNestedPublic == false)))
 					return false;
 
 				if (t.IsEnum)


### PR DESCRIPTION
Class3 not generated.
```csharp
public class Class1 {
    public class Class2 {
        public class Class3 {
        }
    }
}
```