### PR TITLE
in luadebug and editor mode, loadfile return assets's absolute path

### DIFF
--- a/Assets/Plugins/Slua_Managed/LuaState.cs
+++ b/Assets/Plugins/Slua_Managed/LuaState.cs
@@ -1356,9 +1356,14 @@ return dumpstack
 
 #if LUA_DEBUG
 					//get asset's absolute path
-					string projectFn = UnityEditor.AssetDatabase.GetAssetPath(asset);
-					int idx = projectFn.IndexOf("/");
-					absoluteFn = Application.dataPath + projectFn.Substring(idx);
+					string assetFn = UnityEditor.AssetDatabase.GetAssetPath(asset);
+					if (assetFn != ""){
+						//find out asset path, remove assetFn's first "Asset/"
+						int idx = assetFn.IndexOf("/");
+						if(idx > 0){
+							absoluteFn = Application.dataPath + assetFn.Substring(idx);
+						}
+					}
 #endif
 #else
 					asset = (TextAsset)Resources.Load(fn);


### PR DESCRIPTION
I hope to get absolute file path when use debug.getinfo(). In this change if UNITY_EDITOR and LUA_DEBUG macro is open , loadFile function will get assets' absolute path and return it to doBuffer. 
use debug.traceback or debug.info function in lua will output absolute file path.