### PR TITLE
Fix build error in Unity2018.2.15f

### DIFF
--- a/Assets/Slua/Editor/CustomExport.cs
+++ b/Assets/Slua/Editor/CustomExport.cs
@@ -81,6 +81,12 @@ namespace SLua
         {
             "UIWidget.showHandles",
             "UIWidget.showHandlesWithMoveTool",
+            "UnityEngine.QualitySettings.get_streamingMipmapsRenderersPerFrame",
+            "UnityEngine.QualitySettings.set_streamingMipmapsRenderersPerFrame",
+            "UnityEngine.QualitySettings.streamingMipmapsRenderersPerFrame",
+            "UnityEngine.Texture.get_imageContentsHash",
+            "UnityEngine.Texture.set_imageContentsHash",
+            "UnityEngine.Texture.imageContentsHash",
         };
         // black list if white list not given
         public static void OnGetNoUseList(out List<string> list)


### PR DESCRIPTION
编译android平台包时，Lua_UnityEngine_QualitySettings和Lua_UnityEngine_Texture有报错，原因是有些api设计上只有Editor平台能访问，而SLua接口导出时导出了这些api，所以出包时会编译报错。
https://github.com/pangweiwei/slua/issues/251